### PR TITLE
Fix invalid artifact names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: ${{ env.SCHEME }}-${{ github.ref_name }}-${{ github.sha }}.xcresult
+        name: ${{ env.SCHEME }}-${{ github.sha }}.xcresult
         path: ${{ env.TEST_RESULT_BUNDLE }}
 
     - name: Archive build
@@ -115,5 +115,5 @@ jobs:
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.SCHEME }}-${{ github.ref_name }}-${{ github.sha }}.xcarchive
+        name: ${{ env.SCHEME }}-${{ github.sha }}.xcarchive
         path: ${{ runner.temp }}/${{ env.ARCHIVE_PATH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,5 +56,5 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: ${{ env.SCHEME }}-${{ github.ref_name }}-${{ github.sha }}.xcresult
+        name: ${{ env.SCHEME }}-${{ github.sha }}.xcresult
         path: ${{ env.TEST_RESULT_BUNDLE }}


### PR DESCRIPTION
Remove ref name from artifact name. Because the reference name (aka branch name) can contain slashes, it may break the upload-artifact action.