### PR TITLE
Update for Xcode 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Only basic features that almost all projects use, were added in this template:
 * Unit tests and UI tests using Salad
 * GitHub Actions CI configuration that runs the tests and submits the app to TestFlight
 
-Xcode 15.3 or higher is required.
+Xcode 16.0 or higher is required.
 
 ## Code style
 

--- a/TemplateApp.xcodeproj/project.pbxproj
+++ b/TemplateApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -367,7 +367,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1510;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = Q42;
 				TargetAttributes = {
 					D5284F2B2B57C6B600BB32E7 = {
@@ -384,7 +384,6 @@
 				};
 			};
 			buildConfigurationList = D5284F272B57C6B600BB32E7 /* Build configuration list for PBXProject "TemplateApp" */;
-			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -397,6 +396,7 @@
 				D5F745F32BEE48BC0064F06A /* XCRemoteSwiftPackageReference "Salad" */,
 				D58BA4CC2BEE6501000D8420 /* XCRemoteSwiftPackageReference "Factory" */,
 			);
+			preferredProjectObjectVersion = 77;
 			productRefGroup = D5284F2D2B57C6B600BB32E7 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -683,7 +683,6 @@
 		D5284F542B57C6B700BB32E7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1.2.3;
@@ -702,7 +701,6 @@
 		D5284F552B57C6B700BB32E7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1.2.3;
@@ -721,7 +719,6 @@
 		D5284F572B57C6B700BB32E7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1.2.3;
 				DEVELOPMENT_TEAM = "";
@@ -739,7 +736,6 @@
 		D5284F582B57C6B700BB32E7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1.2.3;
 				DEVELOPMENT_TEAM = "";

--- a/TemplateApp.xcodeproj/project.pbxproj
+++ b/TemplateApp.xcodeproj/project.pbxproj
@@ -7,35 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D5284F302B57C6B600BB32E7 /* TemplateAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5284F2F2B57C6B600BB32E7 /* TemplateAppApp.swift */; };
-		D5284F322B57C6B600BB32E7 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5284F312B57C6B600BB32E7 /* RootView.swift */; };
-		D5284F342B57C6B700BB32E7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D5284F332B57C6B700BB32E7 /* Assets.xcassets */; };
-		D5284F372B57C6B700BB32E7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D5284F362B57C6B700BB32E7 /* Preview Assets.xcassets */; };
-		D5284F412B57C6B700BB32E7 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5284F402B57C6B700BB32E7 /* ExampleTests.swift */; };
-		D5284F4B2B57C6B700BB32E7 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5284F4A2B57C6B700BB32E7 /* ExampleUITests.swift */; };
 		D58BA4CE2BEE6501000D8420 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = D58BA4CD2BEE6501000D8420 /* Factory */; };
-		D58BA4D02BEE696D000D8420 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4CF2BEE696D000D8420 /* Container.swift */; };
-		D58BA4D42BEE700D000D8420 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4D32BEE700D000D8420 /* HomeScreen.swift */; };
-		D58BA4D62BEE7012000D8420 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4D52BEE7012000D8420 /* HomeViewModel.swift */; };
-		D58BA4D82BEE702A000D8420 /* HomeViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4D72BEE702A000D8420 /* HomeViewState.swift */; };
-		D58BA4DB2BEE7095000D8420 /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4DA2BEE7095000D8420 /* UserModel.swift */; };
-		D58BA4DD2BEE70A1000D8420 /* UserRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4DC2BEE70A1000D8420 /* UserRepositoryProtocol.swift */; };
-		D58BA4DF2BEE70B8000D8420 /* GetUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4DE2BEE70B8000D8420 /* GetUserUseCase.swift */; };
-		D58BA4E32BEE7101000D8420 /* UserLocalDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4E22BEE7101000D8420 /* UserLocalDataSource.swift */; };
-		D58BA4E72BEE711B000D8420 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4E62BEE711B000D8420 /* UserRepository.swift */; };
-		D58BA4EF2BEE7239000D8420 /* UserEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4EE2BEE7239000D8420 /* UserEntity.swift */; };
-		D58BA4F12BEE725D000D8420 /* UserRemoteDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4F02BEE725D000D8420 /* UserRemoteDataSource.swift */; };
-		D58BA4F42BEE7389000D8420 /* UserEntity+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4F32BEE7389000D8420 /* UserEntity+Model.swift */; };
-		D58BA4F72BEE73A5000D8420 /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4F62BEE73A5000D8420 /* AsyncButton.swift */; };
-		D58BA4FA2BEE73CB000D8420 /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4F92BEE73CB000D8420 /* ErrorAlert.swift */; };
-		D58BA4FC2BEE73E4000D8420 /* TemplateAppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA4FB2BEE73E4000D8420 /* TemplateAppError.swift */; };
-		D58BA5012BEE75B2000D8420 /* Task+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA5002BEE75B2000D8420 /* Task+Extensions.swift */; };
-		D58BA5042BEE761D000D8420 /* RefreshBehaviour.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BA5032BEE761D000D8420 /* RefreshBehaviour.swift */; };
-		D5F745E82BEE14870064F06A /* TemplateAppAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F745E72BEE14870064F06A /* TemplateAppAppDelegate.swift */; };
-		D5F745EA2BEE14DD0064F06A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D5F745E92BEE14DD0064F06A /* Localizable.xcstrings */; };
-		D5F745EF2BEE15C20064F06A /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D5F745EE2BEE15C20064F06A /* Launch Screen.storyboard */; };
 		D5F745F52BEE48BC0064F06A /* Salad in Frameworks */ = {isa = PBXBuildFile; productRef = D5F745F42BEE48BC0064F06A /* Salad */; };
-		D5F745F82BEE48F50064F06A /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F745F72BEE48F50064F06A /* HomeView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,40 +30,42 @@
 
 /* Begin PBXFileReference section */
 		D5284F2C2B57C6B600BB32E7 /* TemplateApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TemplateApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5284F2F2B57C6B600BB32E7 /* TemplateAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateAppApp.swift; sourceTree = "<group>"; };
-		D5284F312B57C6B600BB32E7 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		D5284F332B57C6B700BB32E7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		D5284F362B57C6B700BB32E7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D5284F3C2B57C6B700BB32E7 /* TemplateAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TemplateAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5284F402B57C6B700BB32E7 /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
 		D5284F462B57C6B700BB32E7 /* TemplateAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TemplateAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5284F4A2B57C6B700BB32E7 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
-		D58BA4CF2BEE696D000D8420 /* Container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
-		D58BA4D32BEE700D000D8420 /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
-		D58BA4D52BEE7012000D8420 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
-		D58BA4D72BEE702A000D8420 /* HomeViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewState.swift; sourceTree = "<group>"; };
-		D58BA4DA2BEE7095000D8420 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
-		D58BA4DC2BEE70A1000D8420 /* UserRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryProtocol.swift; sourceTree = "<group>"; };
-		D58BA4DE2BEE70B8000D8420 /* GetUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserUseCase.swift; sourceTree = "<group>"; };
-		D58BA4E22BEE7101000D8420 /* UserLocalDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLocalDataSource.swift; sourceTree = "<group>"; };
-		D58BA4E62BEE711B000D8420 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
-		D58BA4EE2BEE7239000D8420 /* UserEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEntity.swift; sourceTree = "<group>"; };
-		D58BA4F02BEE725D000D8420 /* UserRemoteDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRemoteDataSource.swift; sourceTree = "<group>"; };
-		D58BA4F32BEE7389000D8420 /* UserEntity+Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserEntity+Model.swift"; sourceTree = "<group>"; };
-		D58BA4F62BEE73A5000D8420 /* AsyncButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButton.swift; sourceTree = "<group>"; };
-		D58BA4F92BEE73CB000D8420 /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
-		D58BA4FB2BEE73E4000D8420 /* TemplateAppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateAppError.swift; sourceTree = "<group>"; };
-		D58BA5002BEE75B2000D8420 /* Task+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Extensions.swift"; sourceTree = "<group>"; };
-		D58BA5032BEE761D000D8420 /* RefreshBehaviour.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshBehaviour.swift; sourceTree = "<group>"; };
-		D5F745E72BEE14870064F06A /* TemplateAppAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateAppAppDelegate.swift; sourceTree = "<group>"; };
-		D5F745E92BEE14DD0064F06A /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		D5F745EB2BEE15210064F06A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		D5F745EE2BEE15C20064F06A /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
-		D5F745F02BEE15D70064F06A /* AllTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AllTests.xctestplan; sourceTree = "<group>"; };
-		D5F745F12BEE16E60064F06A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		D5F745F22BEE16FB0064F06A /* TemplateApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TemplateApp.entitlements; sourceTree = "<group>"; };
-		D5F745F72BEE48F50064F06A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D558C8982C986B5500E28A82 /* Exceptions for "TemplateApp" folder in "TemplateApp" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AllTests.xctestplan,
+				Info.plist,
+			);
+			target = D5284F2B2B57C6B600BB32E7 /* TemplateApp */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D558C87E2C986B5500E28A82 /* TemplateApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				D558C8982C986B5500E28A82 /* Exceptions for "TemplateApp" folder in "TemplateApp" target */,
+			);
+			path = TemplateApp;
+			sourceTree = "<group>";
+		};
+		D558C89A2C986B5800E28A82 /* TemplateAppTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TemplateAppTests;
+			sourceTree = "<group>";
+		};
+		D558C8A12C986B5A00E28A82 /* TemplateAppUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TemplateAppUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		D5284F292B57C6B600BB32E7 /* Frameworks */ = {
@@ -123,9 +98,9 @@
 			isa = PBXGroup;
 			children = (
 				D5F745EB2BEE15210064F06A /* README.md */,
-				D5284F2E2B57C6B600BB32E7 /* TemplateApp */,
-				D5284F3F2B57C6B700BB32E7 /* TemplateAppTests */,
-				D5284F492B57C6B700BB32E7 /* TemplateAppUITests */,
+				D558C87E2C986B5500E28A82 /* TemplateApp */,
+				D558C89A2C986B5800E28A82 /* TemplateAppTests */,
+				D558C8A12C986B5A00E28A82 /* TemplateAppUITests */,
 				D5284F2D2B57C6B600BB32E7 /* Products */,
 			);
 			indentWidth = 4;
@@ -142,161 +117,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		D5284F2E2B57C6B600BB32E7 /* TemplateApp */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4CF2BEE696D000D8420 /* Container.swift */,
-				D5284F2F2B57C6B600BB32E7 /* TemplateAppApp.swift */,
-				D5F745E72BEE14870064F06A /* TemplateAppAppDelegate.swift */,
-				D5284F312B57C6B600BB32E7 /* RootView.swift */,
-				D58BA4E12BEE70F1000D8420 /* Data */,
-				D58BA4D92BEE7084000D8420 /* Domain */,
-				D58BA4D12BEE7004000D8420 /* Features */,
-				D58BA4F52BEE739C000D8420 /* UIComponents */,
-				D58BA4F82BEE73C4000D8420 /* ViewModifiers */,
-				D58BA4FF2BEE75AD000D8420 /* Extensions */,
-				D5F745E92BEE14DD0064F06A /* Localizable.xcstrings */,
-				D5284F332B57C6B700BB32E7 /* Assets.xcassets */,
-				D5F745ED2BEE15B80064F06A /* Supporting Files */,
-				D5284F352B57C6B700BB32E7 /* Preview Content */,
-			);
-			path = TemplateApp;
-			sourceTree = "<group>";
-		};
-		D5284F352B57C6B700BB32E7 /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				D5284F362B57C6B700BB32E7 /* Preview Assets.xcassets */,
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		D5284F3F2B57C6B700BB32E7 /* TemplateAppTests */ = {
-			isa = PBXGroup;
-			children = (
-				D5284F402B57C6B700BB32E7 /* ExampleTests.swift */,
-			);
-			path = TemplateAppTests;
-			sourceTree = "<group>";
-		};
-		D5284F492B57C6B700BB32E7 /* TemplateAppUITests */ = {
-			isa = PBXGroup;
-			children = (
-				D5284F4A2B57C6B700BB32E7 /* ExampleUITests.swift */,
-				D58BA5022BEE7616000D8420 /* Behaviours */,
-				D5F745F62BEE48EF0064F06A /* ViewObjects */,
-			);
-			path = TemplateAppUITests;
-			sourceTree = "<group>";
-		};
-		D58BA4D12BEE7004000D8420 /* Features */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4D22BEE7008000D8420 /* Home */,
-			);
-			path = Features;
-			sourceTree = "<group>";
-		};
-		D58BA4D22BEE7008000D8420 /* Home */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4D32BEE700D000D8420 /* HomeScreen.swift */,
-				D58BA4D52BEE7012000D8420 /* HomeViewModel.swift */,
-				D58BA4D72BEE702A000D8420 /* HomeViewState.swift */,
-			);
-			path = Home;
-			sourceTree = "<group>";
-		};
-		D58BA4D92BEE7084000D8420 /* Domain */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4E02BEE70EB000D8420 /* User */,
-				D58BA4FB2BEE73E4000D8420 /* TemplateAppError.swift */,
-			);
-			path = Domain;
-			sourceTree = "<group>";
-		};
-		D58BA4E02BEE70EB000D8420 /* User */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4DA2BEE7095000D8420 /* UserModel.swift */,
-				D58BA4DC2BEE70A1000D8420 /* UserRepositoryProtocol.swift */,
-				D58BA4DE2BEE70B8000D8420 /* GetUserUseCase.swift */,
-			);
-			path = User;
-			sourceTree = "<group>";
-		};
-		D58BA4E12BEE70F1000D8420 /* Data */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4E82BEE711F000D8420 /* User */,
-			);
-			path = Data;
-			sourceTree = "<group>";
-		};
-		D58BA4E82BEE711F000D8420 /* User */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4EE2BEE7239000D8420 /* UserEntity.swift */,
-				D58BA4E62BEE711B000D8420 /* UserRepository.swift */,
-				D58BA4F32BEE7389000D8420 /* UserEntity+Model.swift */,
-				D58BA4F02BEE725D000D8420 /* UserRemoteDataSource.swift */,
-				D58BA4E22BEE7101000D8420 /* UserLocalDataSource.swift */,
-			);
-			path = User;
-			sourceTree = "<group>";
-		};
-		D58BA4F52BEE739C000D8420 /* UIComponents */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4F62BEE73A5000D8420 /* AsyncButton.swift */,
-			);
-			path = UIComponents;
-			sourceTree = "<group>";
-		};
-		D58BA4F82BEE73C4000D8420 /* ViewModifiers */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA4F92BEE73CB000D8420 /* ErrorAlert.swift */,
-			);
-			path = ViewModifiers;
-			sourceTree = "<group>";
-		};
-		D58BA4FF2BEE75AD000D8420 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA5002BEE75B2000D8420 /* Task+Extensions.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		D58BA5022BEE7616000D8420 /* Behaviours */ = {
-			isa = PBXGroup;
-			children = (
-				D58BA5032BEE761D000D8420 /* RefreshBehaviour.swift */,
-			);
-			path = Behaviours;
-			sourceTree = "<group>";
-		};
-		D5F745ED2BEE15B80064F06A /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				D5F745F02BEE15D70064F06A /* AllTests.xctestplan */,
-				D5F745F12BEE16E60064F06A /* Info.plist */,
-				D5F745EE2BEE15C20064F06A /* Launch Screen.storyboard */,
-				D5F745F22BEE16FB0064F06A /* TemplateApp.entitlements */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		D5F745F62BEE48EF0064F06A /* ViewObjects */ = {
-			isa = PBXGroup;
-			children = (
-				D5F745F72BEE48F50064F06A /* HomeView.swift */,
-			);
-			path = ViewObjects;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -311,6 +131,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D558C87E2C986B5500E28A82 /* TemplateApp */,
 			);
 			name = TemplateApp;
 			packageProductDependencies = (
@@ -333,6 +156,9 @@
 			dependencies = (
 				D5284F3E2B57C6B700BB32E7 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				D558C89A2C986B5800E28A82 /* TemplateAppTests */,
+			);
 			name = TemplateAppTests;
 			productName = TemplateAppTests;
 			productReference = D5284F3C2B57C6B700BB32E7 /* TemplateAppTests.xctest */;
@@ -350,6 +176,9 @@
 			);
 			dependencies = (
 				D5284F482B57C6B700BB32E7 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				D558C8A12C986B5A00E28A82 /* TemplateAppUITests */,
 			);
 			name = TemplateAppUITests;
 			packageProductDependencies = (
@@ -413,10 +242,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5284F372B57C6B700BB32E7 /* Preview Assets.xcassets in Resources */,
-				D5284F342B57C6B700BB32E7 /* Assets.xcassets in Resources */,
-				D5F745EF2BEE15C20064F06A /* Launch Screen.storyboard in Resources */,
-				D5F745EA2BEE14DD0064F06A /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -441,25 +266,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D58BA4E72BEE711B000D8420 /* UserRepository.swift in Sources */,
-				D5F745E82BEE14870064F06A /* TemplateAppAppDelegate.swift in Sources */,
-				D58BA4DF2BEE70B8000D8420 /* GetUserUseCase.swift in Sources */,
-				D58BA4FA2BEE73CB000D8420 /* ErrorAlert.swift in Sources */,
-				D58BA4E32BEE7101000D8420 /* UserLocalDataSource.swift in Sources */,
-				D58BA4D62BEE7012000D8420 /* HomeViewModel.swift in Sources */,
-				D58BA5012BEE75B2000D8420 /* Task+Extensions.swift in Sources */,
-				D58BA4DD2BEE70A1000D8420 /* UserRepositoryProtocol.swift in Sources */,
-				D58BA4F72BEE73A5000D8420 /* AsyncButton.swift in Sources */,
-				D58BA4EF2BEE7239000D8420 /* UserEntity.swift in Sources */,
-				D58BA4D02BEE696D000D8420 /* Container.swift in Sources */,
-				D58BA4D82BEE702A000D8420 /* HomeViewState.swift in Sources */,
-				D58BA4DB2BEE7095000D8420 /* UserModel.swift in Sources */,
-				D58BA4F42BEE7389000D8420 /* UserEntity+Model.swift in Sources */,
-				D5284F322B57C6B600BB32E7 /* RootView.swift in Sources */,
-				D58BA4FC2BEE73E4000D8420 /* TemplateAppError.swift in Sources */,
-				D58BA4D42BEE700D000D8420 /* HomeScreen.swift in Sources */,
-				D5284F302B57C6B600BB32E7 /* TemplateAppApp.swift in Sources */,
-				D58BA4F12BEE725D000D8420 /* UserRemoteDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -467,7 +273,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5284F412B57C6B700BB32E7 /* ExampleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -475,9 +280,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5F745F82BEE48F50064F06A /* HomeView.swift in Sources */,
-				D5284F4B2B57C6B700BB32E7 /* ExampleUITests.swift in Sources */,
-				D58BA5042BEE761D000D8420 /* RefreshBehaviour.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TemplateApp.xcodeproj/xcshareddata/xcschemes/TemplateApp.xcscheme
+++ b/TemplateApp.xcodeproj/xcshareddata/xcschemes/TemplateApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TemplateApp/Localizable.xcstrings
+++ b/TemplateApp/Localizable.xcstrings
@@ -1,16 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "An error occurred" : {
-      "localizations" : {
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er is een fout opgetreden"
-          }
-        }
-      }
-    },
     "Home" : {
       "localizations" : {
         "nl" : {


### PR DESCRIPTION
## Changes

1. Update Xcode project to require Xcode 16.0 and apply recommended build settings
2. [Convert targets to use buildable folder references](https://github.com/Q42/template-ios/commit/0ff162a1ce7e0345c9f190e997abdb207e3e8519) 

This is the new default behaviour in Xcode 16. From the Xcode release notes:

Minimize project file changes, and avoid version control conflicts with buildable folder references.
Convert an existing group to a buildable folder with the “Convert to Folder” context menu item in the Project Navigator. Buildable folders only record the folder path into the project file without enumerating the contained files. This minimizes diffs to the project when files are added and removed, and avoids source control conflicts with your team.

https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes

## Backwards compatibility note:

* Xcode 16.0 is required from now on to use the template