### PR TITLE
Fix iOS Simulator selection in test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,9 @@ jobs:
 
     - name: Run tests
       env:
-        PLATFORM: ${{ 'iOS Simulator' }}
+        PLATFORM: 'iOS Simulator'
+        DEVICE: 'iPhone 16'
       run: |
-        # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-        DEVICE=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
         set -o pipefail && xcodebuild test -project "${{ env.XCODE_PROJECT }}" \
           -scheme "${{ env.SCHEME }}" \
           -testPlan "${{ env.TEST_PLAN }}" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,13 +69,13 @@ jobs:
       run: |
         # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
         DEVICE=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-        xcodebuild test -project "${{ env.XCODE_PROJECT }}" \
+        set -o pipefail && xcodebuild test -project "${{ env.XCODE_PROJECT }}" \
           -scheme "${{ env.SCHEME }}" \
           -testPlan "${{ env.TEST_PLAN }}" \
           -destination "platform=$PLATFORM,name=$DEVICE" \
           -resultBundlePath "${{ env.TEST_RESULT_BUNDLE }}" \
           -clonedSourcePackagesDirPath "${{ runner.temp }}/SourcePackages" \
-          -disableAutomaticPackageResolution
+          -disableAutomaticPackageResolution | xcpretty
 
     - name: Upload test result bundle
       uses: actions/upload-artifact@v4
@@ -86,7 +86,7 @@ jobs:
 
     - name: Archive build
       run: |
-        xcodebuild clean archive -project "${{ env.XCODE_PROJECT }}" \
+        set -o pipefail && xcodebuild clean archive -project "${{ env.XCODE_PROJECT }}" \
           -scheme "${{ env.SCHEME }}" \
           -destination generic/platform=iOS \
           -archivePath "${{ runner.temp }}/${{ env.ARCHIVE_PATH }}" \
@@ -95,7 +95,7 @@ jobs:
           -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
           -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }} \
           -clonedSourcePackagesDirPath "${{ runner.temp }}/SourcePackages" \
-          -disableAutomaticPackageResolution
+          -disableAutomaticPackageResolution | xcpretty
 
     - name: Upload to TestFlight
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Run tests
 on:
   pull_request:
     branches: ["main"]
+  push:
+    branches: ["main"]
 
 env:
   XCODE_PROJECT: TemplateApp.xcodeproj

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,21 +52,21 @@ jobs:
 
     - name: Build for testing
       run: |
-        xcodebuild build-for-testing -project "${{ env.XCODE_PROJECT }}" \
+        set -o pipefail && xcodebuild build-for-testing -project "${{ env.XCODE_PROJECT }}" \
           -scheme "${{ env.SCHEME }}" \
           -destination "platform=$PLATFORM,name=$DEVICE" \
           -clonedSourcePackagesDirPath "${{ runner.temp }}/SourcePackages" \
-          -disableAutomaticPackageResolution
+          -disableAutomaticPackageResolution | xcpretty
 
     - name: Run tests
       run: |
-        xcodebuild test-without-building -project "${{ env.XCODE_PROJECT }}" \
+        set -o pipefail && xcodebuild test-without-building -project "${{ env.XCODE_PROJECT }}" \
           -scheme "${{ env.SCHEME }}" \
           -testPlan "${{ env.TEST_PLAN }}" \
           -destination "platform=$PLATFORM,name=$DEVICE" \
           -resultBundlePath "${{ env.TEST_RESULT_BUNDLE }}" \
           -clonedSourcePackagesDirPath "${{ runner.temp }}/SourcePackages" \
-          -disableAutomaticPackageResolution
+          -disableAutomaticPackageResolution | xcpretty
 
     - name: Upload test result bundle
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ jobs:
   build:
     name: Run tests
     runs-on: [macos-latest]
+
+    env:
+        PLATFORM: 'iOS Simulator'
+        DEVICE: 'iPhone 16'
   
     steps:
     - name: Checkout
@@ -45,12 +49,6 @@ jobs:
           -onlyUsePackageVersionsFromResolvedFile \
           -resolvePackageDependencies \
           -clonedSourcePackagesDirPath "${{ runner.temp }}/SourcePackages"
-
-    - name: Determine test device
-      run: |
-        echo "PLATFORM=iOS Simulator" >> "$GITHUB_ENV"
-        # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-        echo "DEVICE=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//")" >> "$GITHUB_ENV"
 
     - name: Build for testing
       run: |


### PR DESCRIPTION
The GitHub Actions workflows that run automated tests had some complicated code for determining which simulator to run on:

```bash
# xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
DEVICE=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
```

This code was **working** on our self-hosted runner but **failing** on GitHub hosted runners, where it would select an unavailable device. I've tried many different things but could not fix it. 

To work around the issue, this PR hard-codes the simulator destination to 'iPhone 16'.