### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*.swift]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = crlf
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true


### PR DESCRIPTION
Xcode respects the [`.editorconfig`](https://editorconfig.org/) standard that lets it automatically recognise the code style of the project. See also: https://www.polpiella.dev/xcode-editor-config

I've added a basic EditorConfig file configured for an indentation of 4 spaces.