### PR TITLE
Update project settings for Xcode 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Only basic features that almost all projects use, were added in this template:
 * Unit tests and UI tests using Salad
 * GitHub Actions CI configuration that runs the tests and submits the app to TestFlight
 
-Xcode 16.0 or higher is required.
+Xcode 26 or higher is required.
 
 ## Code style
 

--- a/TemplateApp.xcodeproj/project.pbxproj
+++ b/TemplateApp.xcodeproj/project.pbxproj
@@ -190,7 +190,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1510;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 2600;
 				ORGANIZATIONNAME = Q42;
 				TargetAttributes = {
 					D5284F2B2B57C6B600BB32E7 = {
@@ -340,6 +340,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
@@ -398,6 +399,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
@@ -430,7 +432,10 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.q42.TemplateApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -461,7 +466,10 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.q42.TemplateApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -577,7 +585,7 @@
 			repositoryURL = "https://github.com/hmlongco/Factory.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.3.2;
+				minimumVersion = 2.5.3;
 			};
 		};
 		D5F745F32BEE48BC0064F06A /* XCRemoteSwiftPackageReference "Salad" */ = {

--- a/TemplateApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TemplateApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hmlongco/Factory.git",
       "state" : {
-        "revision" : "c8110886836ab4dd1136dbac0c04f0f36cd68540",
-        "version" : "2.4.5"
+        "revision" : "ccc898f21992ebc130bc04cc197460a5ae230bcf",
+        "version" : "2.5.3"
       }
     },
     {

--- a/TemplateApp.xcodeproj/xcshareddata/xcschemes/TemplateApp.xcscheme
+++ b/TemplateApp.xcodeproj/xcshareddata/xcschemes/TemplateApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "2600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TemplateApp/Data/UserAgent.swift
+++ b/TemplateApp/Data/UserAgent.swift
@@ -12,7 +12,7 @@ import UIKit
 /// Returns the user agent string for this device, consisting of the app name, app version, build number, OS version and device model.
 /// eg. MyApp/1.0 (1; iOS/18.3; iPhone13,2)
 /// This format is consistent with the Android app template.
-@MainActor func userAgentString() -> String {
+func userAgentString() -> String {
     let info = Bundle.main.infoDictionary
     let appName = info?["CFBundleName"] as? String ?? "unknown"
     let appVersion = info?["CFBundleShortVersionString"] as? String ?? "unknown"

--- a/TemplateApp/Views/Home/HomeViewModel.swift
+++ b/TemplateApp/Views/Home/HomeViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @Observable
-@MainActor class HomeViewModel {
+class HomeViewModel {
     var state: HomeViewState = .empty
 
     func refresh() async {


### PR DESCRIPTION
Added build settings:
- Approachable concurrency: yes
- Default actor isolation: MainActor
- Strict concurrency checking: complete
- Enabled type safe localized string symbol generation

Update Factory to version 2.5.3.

The deployment target remains on iOS 17.6.
