### PR TITLE
Update test workflow triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 name: Run tests
 
 on:
-  # Run on pull requests that target the main branch
-  pull_request:
-    branches: ["main"]
+  # Run on pushes to the main branch
+  push:
+    branches: [ "main" ]
 
-  # Show a manual trigger button in the GitHub Actions UI
-  workflow_dispatch:
+  # Run for any pull request
+  pull_request:
 
 env:
   XCODE_VERSION: '26'


### PR DESCRIPTION
## Description

Run the tests on CI:

- On pushes to the main branch
- For any pull request (this now includes stacked PR’s)

A frequent annoyance was, that when the base branch of a stacked PR is merged, the tests wouldn't trigger. This resolves that.

Removed the manual trigger since that shouldn't be necessary now.